### PR TITLE
Fix for https://wordpress.org/support/topic/users-whove-unsubscribed-still-get-emails-in-a-roundabout-way/

### DIFF
--- a/wpmandrill.php
+++ b/wpmandrill.php
@@ -66,7 +66,7 @@ class wpMandrill {
 					
 					if (    is_wp_error($sent) 
 					        || !isset($sent[0]['status']) 
-					        || ($sent[0]['status'] != 'sent' && $sent[0]['status'] != 'queued') ) {
+					        || ($sent[0]['status'] != 'sent' && $sent[0]['status'] != 'queued' && $sent[0]['status'] != 'rejected') ) {
 					        
                         return wpMandrill::wp_mail_native( $to, $subject, $message, $headers, $attachments );
                     }


### PR DESCRIPTION
I'm not sure this is perfect, because there are some rejection reasons that rightfully should cause the whole batch to be rejected (e.g. invalid sender). But I'm not sure the right answer here is to send emails via the original wp_mail function instead. If you ask me, this plugin should probably never send things via wp_mail.