### PR TITLE
#3 Added in multisite support based on wpMandrillMultisite

### DIFF
--- a/lib/wpMandrillMultisite.class.php
+++ b/lib/wpMandrillMultisite.class.php
@@ -1,0 +1,86 @@
+<?php
+/*
+Originally forked from wpMandrill Multisite
+
+Automatically propagates the wpMandrill settings from the main site to all subsites, still allowing each subsite to manually override them.
+Original Author: tyxla (http://marinatanasov.com/)
+
+*/
+
+/**
+ * Class wpMandrill_Multisite
+ */
+class wpMandrill_Multisite {
+
+	/**
+	 * Constructor.
+	 *
+	 * Initializes and hooks the plugin functionality.
+	 *
+	 * @access public
+	 *
+	 */
+	public function __construct() {
+		add_action( 'wp_loaded', array( $this, 'distribute_settings' ) );
+	}
+
+	/**
+	 * Distribute wpMandrill's settings throughout the entire network.
+	 *
+	 * Called on each of the subsites, populates the wpMandrill settings
+	 * if they are not configured. This allows wpMandrill to work on the
+	 * entire network without having to set it up manually on each subsite.
+	 *
+	 * @access public
+	 */
+	public function distribute_settings() {
+
+		// bail if multisite is not enabled
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		// allow site ID to be filtered
+		$site_id = apply_filters( 'wpmandrill_multisite_site_id', BLOG_ID_CURRENT_SITE );
+
+		// get mandrill settings from main site
+		$mainsite_mandrill_settings = get_blog_option( $site_id, 'wpmandrill' );
+
+		// we should not continue if wpMandrill is not setup in the main site
+		if ( ! $mainsite_mandrill_settings ) {
+			return;
+		}
+
+		// the current blog ID
+		$current_blog_id = get_current_blog_id();
+
+		// allow propagation to be disabled for a particular site, or for the entire network
+		$allow_propagation = apply_filters( 'wpmandrill_multisite_propagation', true, $current_blog_id );
+
+		if ( ! $allow_propagation ) {
+			return;
+		}
+
+		// get mandrill settings from subsite
+		$mandrill_settings = get_option( 'wpmandrill' );
+
+		// if the settings are not setup in the subsite, set them up
+		if ( ! $mandrill_settings ) {
+			$mandrill_settings = $mainsite_mandrill_settings;
+
+			// use the from name and email from the subsite
+			$mandrill_settings['from_name']     = get_bloginfo( 'name' );
+			$mandrill_settings['from_username'] = get_bloginfo( 'admin_email' );
+
+			// allow wpMandrill settings to be modified for each blog, or for the entire network
+			$mandrill_settings = apply_filters( 'wpmandrill_multisite_settings', $mandrill_settings, $current_blog_id );
+
+			// save wpMandrill options for the subsite
+			update_option( 'wpmandrill', $mandrill_settings );
+		}
+	}
+}
+
+// initialize wpMandrill Multisite
+global $wp_mandrill_multisite;
+$wp_mandrill_multisite = new wpMandrill_Multisite();

--- a/wpmandrill.php
+++ b/wpmandrill.php
@@ -1,5 +1,5 @@
 <?php
-/* 
+/*
 Plugin Name: Send E-mails with Mandrill
 Description: Send e-mails using Mandrill. This is a forked version of the now unsupported plugin <a href="https://wordpress.org/plugins/wpmandrill/">wpMandrill</a>.
 Author: Miller Media ( Matt Miller )
@@ -28,20 +28,26 @@ Text Domain: send-emails-with-mandrill
 
 */
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 // Define plugin constants
 
-if ( !defined( 'SEWM_BASE' ) )
+if ( ! defined( 'SEWM_BASE' ) ) {
 	define( 'SEWM_BASE', plugin_basename( __FILE__ ) );
+}
 
-if ( !defined( 'SEWM_URL' ) )
+if ( ! defined( 'SEWM_URL' ) ) {
 	define( 'SEWM_URL', plugin_dir_url( __FILE__ ) );
+}
 
-if ( !defined( 'SEWM_PATH' ) )
+if ( ! defined( 'SEWM_PATH' ) ) {
 	define( 'SEWM_PATH', plugin_dir_path( __FILE__ ) );
+}
 
-include( plugin_dir_path( __FILE__ ) . 'lib/pluginActivation.class.php');
-include( plugin_dir_path( __FILE__ ) . 'lib/wpMandrill.class.php');
+require_once plugin_dir_path( __FILE__ ) . 'lib/pluginActivation.class.php';
+require_once plugin_dir_path( __FILE__ ) . 'lib/wpMandrill.class.php';
+require_once plugin_dir_path( __FILE__ ) . 'lib/wpMandrillMultisite.class.php';
 
 wpMandrill::on_load();


### PR DESCRIPTION
Some notes.

The original plugin was a self contained class. I left it pretty much as is excluding the following changes.

Changed  up the usage of `include()` to be `require_once`
Applies WPCS to the main plugin file and the wpMandrillMultisite.class.php I added to the project though the naming conventions used in the plugin does not allow for full compliance with WPCS but I figure that was a topic for another day.
