### PR TITLE
Ensures that emails recipients with "name" <myname@domain.com> are no…

### DIFF
--- a/lib/wpMandrill.class.php
+++ b/lib/wpMandrill.class.php
@@ -1776,7 +1776,7 @@ JS;
                 if ( is_array($email) ) {
                     $processed_to[] = $email;
                 } else {
-                    $processed_to[] = array( 'email' => $email );
+                    $processed_to[] = self::ensureEmailFormatting( $email );
                 }
             }
             $message['to'] = $processed_to;
@@ -1906,6 +1906,27 @@ JS;
         $wp 	= $wp_version;
 
         return "wpMandrill/$me (PHP/$php; WP/$wp)";
+    }
+    
+    /**
+     * Ensures the email field sent to Mandrill is formatted accordingly for emails with the name formatting
+     *
+     * @param $email
+     * @param string $type
+     * @return array
+     */
+    static function ensureEmailFormatting( $email, $type = 'to' ) {
+        if( preg_match( '/(.*)<(.+)>/', $email, $matches ) ) {
+            if ( count( $matches ) == 3 ) {
+                return array(
+                    'email' => $matches[2],
+                    'name' => $matches[1],
+                    'type' => $type
+                );
+            }
+        }
+        
+        return array( 'email' => $email );
     }
 }
 


### PR DESCRIPTION
…t marked as invalid when sent through Mandrill by using the right array formatting.

I have noticed this error on Mandrill when Jetpack specifically adds names to emails. 
see https://github.com/Automattic/jetpack/blob/master/modules/contact-form/grunion-contact-form.php#L2865

Sample response from Mandrill in this case
```
[
    {
        "email": "\"diego.gullo\" <diego.gullo@domain.com>",
        "status": "invalid",
        "_id": "a.......................e",
        "reject_reason": null
    }
]
```

The plugin at the moment is failing in its new version so I just added a function to ensure the formatting is consistent with the Mandrill requested object for the TO recipient.

When an email with `"name" <myaddress@domain.com>` is used as the recipient Mandrill expects this to be sent as

```
"to": [
            {
                "email": "recipient.email@example.com",
                "name": "Recipient Name",
                "type": "to"
            }
        ]
```

