### PR TITLE
Stop autoloading wpmandrill-stats

### DIFF
--- a/lib/wpMandrill.class.php
+++ b/lib/wpMandrill.class.php
@@ -1002,7 +1002,7 @@ class wpMandrill {
         $stats = self::GetProcessedStats();
         if ( !empty($stats) ) {
             set_transient('wpmandrill-stats', $stats, 60 * 60);
-            update_option('wpmandrill-stats', $stats);
+            update_option('wpmandrill-stats', $stats, false);
         } else {
             error_log( date('Y-m-d H:i:s') . " wpMandrill::saveProcessedStats (Empty Response from ::GetProcessedStats)\n" );
         }


### PR DESCRIPTION
Stop autoloading wpmandrill-stats. This this is to fix #49, where it can cause a problem with memcached options object growing too large.