### PR TITLE
Filters to Disable Reports and Dashboard Widgets

### DIFF
--- a/lib/wpMandrill.class.php
+++ b/lib/wpMandrill.class.php
@@ -1030,7 +1030,7 @@ class wpMandrill {
         if (!current_user_can('manage_options')) return;
 
         self::getConnected();
-        if ( !self::isConnected() ) return;
+        if ( !self::isConnected() || !apply_filters( 'wpmandrill_enable_widgets', true ) ) return;
 
         $widget_id      = 'mandrill_widget';
 

--- a/lib/wpMandrill.class.php
+++ b/lib/wpMandrill.class.php
@@ -153,7 +153,7 @@ class wpMandrill {
             array(__CLASS__,'showOptionsPage')
         );
 
-        if( self::isConfigured() ) {
+        if( self::isConfigured() && apply_filters( 'wpmandrill_enable_reports', true ) ) {
             if (current_user_can('manage_options')) self::$report = add_dashboard_page(
                 __('Mandrill Reports', 'wpmandrill'),
                 __('Mandrill Reports', 'wpmandrill'),


### PR DESCRIPTION
Simple filters that allow for the admin page Mandrill Reports and the dashboard Mandrill Widget to be disabled. Here is the usage for the new filters.

`add_filter( 'wpmandrill_enable_reports', '__return_false' );`
`add_filter( 'wpmandrill_enable_widgets', '__return_false' );`

This is related to Issue #54.

Link to my [WordPress profile](https://profiles.wordpress.org/srumery/).