### PR TITLE
Modified isTemplateValid() in lib/wpMandrill.class.php to check for s…

### DIFF
--- a/lib/wpMandrill.class.php
+++ b/lib/wpMandrill.class.php
@@ -583,7 +583,7 @@ class wpMandrill {
 
         $templates = self::$mandrill->templates_list();
         foreach ( $templates as $curtemplate )  {
-            if ( $curtemplate['name'] == $template ) {
+			if ( $curtemplate['name'] == $template || $curtemplate['slug'] == $template) {
                 return true;
             }
         }


### PR DESCRIPTION
…lugs too

Based on this discussion:

https://wordpress.org/support/topic/istemplatevalid-should-check-slugs-too/#post-13254894

