### PR TITLE
Add action hook for monitoring Mandrill API response

### DIFF
--- a/lib/wpMandrill.class.php
+++ b/lib/wpMandrill.class.php
@@ -59,6 +59,8 @@ class wpMandrill {
 
         if ( !isset( $response[0]['status'] ) )
             throw new Exception( 'Email status was not provided in response.' );
+	    
+	do_action( 'mandrill_response_received', $response );
 
         if (
             'rejected' === $response[0]['status']


### PR DESCRIPTION
I use this on a client's site to confirm the connection between WordPress and Mandrill is active and healthy. Would be nice to have it find a permanent place in the plugin, rather than having to add it after each version.