### PR TITLE
Bug fix - Incorrect Parameter Name in wpMandrill Plugin - 'meta_data' should be 'metadata'

### DIFF
--- a/lib/wpMandrill.class.php
+++ b/lib/wpMandrill.class.php
@@ -1668,7 +1668,7 @@ JS;
      * @param array $merge_vars Per-recipient merge variables, which override global merge variables with the same name.
      * @param array $google_analytics_domains An array of strings indicating for which any matching URLs will automatically have Google Analytics parameters appended to their query string automatically.
      * @param array|string $google_analytics_campaign Optional string indicating the value to set for the utm_campaign tracking parameter. If this isn't provided the email's from address will be used instead.
-     * @param array $meta_data Associative array of user metadata. Mandrill will store this metadata and make it available for retrieval. In addition, you can select up to 10 metadata fields to index and make searchable using the Mandrill search api.
+     * @param array $metadata Associative array of user metadata. Mandrill will store this metadata and make it available for retrieval. In addition, you can select up to 10 metadata fields to index and make searchable using the Mandrill search api.
      * @param boolean $important Set the important flag to true for the current email
      * @param boolean $inline_css whether or not to automatically inline all CSS styles provided in the message HTML - only for HTML documents less than 256KB in size
      * @param boolean $preserve_recipients whether or not to expose all recipients in to "To" header for each email
@@ -1696,7 +1696,7 @@ JS;
                           $merge_vars = array(),
                           $google_analytics_domains = array(),
                           $google_analytics_campaign = array(),
-                          $meta_data = array(),
+                          $metadata = array(),
                           $important = false,
                           $inline_css = null,
                           $preserve_recipients=null,
@@ -1722,7 +1722,7 @@ JS;
                 'merge_vars',
                 'google_analytics_domains',
                 'google_analytics_campaign',
-                'meta_data',
+                'metadata',
                 'important',
                 'inline_css',
                 'preserve_recipients',


### PR DESCRIPTION
This is a legit bug that prevents us from using the metadata feature of the mandrill. see the details [here](https://github.com/Miller-Media/send-emails-with-mandrill/issues/91)