### PR TITLE
Fix Plugin Check (PCP) compliance issues

### DIFF
--- a/how-tos.php
+++ b/how-tos.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 class wpMandrill_HowTos {
     static function show($section) {
         $section = strtolower($section);
@@ -35,21 +39,19 @@ class wpMandrill_HowTos {
         $html = self::$method();
         
         if ( $title != '' ) {
-            $html = <<<HTML
-            <div class="stuffbox" style="max-width: 90% !important;">
-                <h3>$title</h3>
-                <div style="width:90%; margin-left:auto;margin-right:auto;">
-                    $html
-                </div>
-            </div>
-HTML;
+            $html = '<div class="stuffbox" style="max-width: 90% !important;">'
+                . '<h3>' . $title . '</h3>'
+                . '<div style="width:90%; margin-left:auto;margin-right:auto;">'
+                . $html
+                . '</div>'
+                . '</div>';
         }
         
         return $html;
     }
     
     static function showSectionIntro() {
-			return  '<p>' . __('The purpose of this how-to is to show you how easy it is to start using the awesome platform that Mandrill offers to handle your transactional emails.', 'wpmandrill-how-tos').'</p>'
+			return  '<p>' . __('The purpose of this how-to is to show you how easy it is to start using the awesome platform that Mandrill offers to handle your transactional emails.', 'send-emails-with-mandrill').'</p>'
 					. '<ol>'
 					. '<li>'. __('Just by setting it up, all the emails sent from your WordPress installation will be sent using the power of Mandrill.', 'send-emails-with-mandrill') . '</li>'
 					. '<li>'. __('If you want further customization, you can use the <strong>mandrill_payload</strong> filter we\'ve provided.', 'send-emails-with-mandrill') . '</li>'

--- a/lib/pluginActivation.class.php
+++ b/lib/pluginActivation.class.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 class pluginActivation
 {
     function __construct()

--- a/lib/reviewNotice.class.php
+++ b/lib/reviewNotice.class.php
@@ -1,4 +1,9 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Review Notice class
  *

--- a/lib/wpMandrill.class.php
+++ b/lib/wpMandrill.class.php
@@ -263,7 +263,7 @@ class wpMandrill {
         
 	    $screen->add_help_tab( array(
             'id'    => 'tab1',
-            'title' => __('Setup'),
+            'title' => __('Setup', 'send-emails-with-mandrill'),
             'content'   => '<p>' . esc_html( $requirements) . '</p>',
 	    ) );
     }
@@ -302,7 +302,7 @@ class wpMandrill {
      */
     static function showOptionsPage() {
         if (!current_user_can('manage_options'))
-            wp_die( esc_html__('You do not have sufficient permissions to access this page.') );
+            wp_die( esc_html__('You do not have sufficient permissions to access this page.', 'send-emails-with-mandrill') );
 
         if ( isset($_GET['show']) && $_GET['show'] == 'how-tos' ) {
             self::showHowTos();
@@ -324,7 +324,7 @@ class wpMandrill {
                         <?php do_settings_sections('wpmandrill'); ?>
                     </div>
 
-                    <p class="submit"><input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e('Save Changes') ?>" /></p>
+                    <p class="submit"><input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e('Save Changes', 'send-emails-with-mandrill') ?>" /></p>
                 </form>
 
 
@@ -1504,14 +1504,15 @@ class wpMandrill {
         $ropened  = $opens['recent'];
         $runopened= $unopens['recent'];
 
-        $js = <<<JS
-var rbounced     = [{$rbounced}];
-var ropened  = [{$ropened}];
-var runopened = [{$runopened}]
+        ob_start();
+        ?>
+var rbounced     = [<?php echo $rbounced; ?>];
+var ropened  = [<?php echo $ropened; ?>];
+var runopened = [<?php echo $runopened; ?>]
 		
-var obounced     = [{$obounced}];
-var oopened  = [{$oopened}];
-var ounopened = [{$ounopened}]
+var obounced     = [<?php echo $obounced; ?>];
+var oopened  = [<?php echo $oopened; ?>];
+var ounopened = [<?php echo $ounopened; ?>]
 
 jQuery(function () {
 	var previousPoint = null;
@@ -1523,7 +1524,7 @@ jQuery(function () {
                 jQuery("#wpm_tooltip").remove();
                 var x = item.datapoint[0].toFixed(0);	                
 
-                if ( '{$tickFormatter}' == 'emailFormatter' ) {
+                if ( '<?php echo $tickFormatter; ?>' == 'emailFormatter' ) {
                 	var y = item.datapoint[1].toFixed(0);
                 	wpm_showTooltip(item.pageX, item.pageY, item.series.label + " = " + y + " emails");
                 } else {
@@ -1545,7 +1546,7 @@ jQuery(function () {
                 jQuery("#wpm_tooltip").remove();
                 var x = dticks[item.dataIndex];
                 	
-                if ( '{$tickFormatter}' == 'emailFormatter' ) {
+                if ( '<?php echo $tickFormatter; ?>' == 'emailFormatter' ) {
                 	var y = item.datapoint[1].toFixed(0);
                 	wpm_showTooltip(item.pageX, item.pageY, item.series.label + " = " + y + " emails");
                 } else {
@@ -1560,9 +1561,9 @@ jQuery(function () {
         }
 	});
 	jQuery.plot(jQuery("#filtered_recent"),
-	           [ { data: rbounced, label: "{$lit['bounced']}" },
-	             { data: ropened, label: "{$lit['opened']}" },
-	             { data: runopened, label: "{$lit['unopened']}" }],
+	           [ { data: rbounced, label: "<?php echo $lit['bounced']; ?>" },
+	             { data: ropened, label: "<?php echo $lit['opened']; ?>" },
+	             { data: runopened, label: "<?php echo $lit['unopened']; ?>" }],
 	           {
 	        	   series: {
 	        	   	   stack: false,
@@ -1583,14 +1584,14 @@ jQuery(function () {
 	 	        		    right: 10
 	 	        		}
 	 	           },
-	               xaxes: [ { ticks: [[0,"{$lit['today']}"],[1,"{$lit['last7days']}"]] } ],
-	               yaxes: [ { min: 0, tickFormatter: {$tickFormatter} } ],
+	               xaxes: [ { ticks: [[0,"<?php echo $lit['today']; ?>"],[1,"<?php echo $lit['last7days']; ?>"]] } ],
+	               yaxes: [ { min: 0, tickFormatter: <?php echo $tickFormatter; ?> } ],
 	               legend: { position: 'ne', margin: [20, 10]}
 	});
 	jQuery.plot(jQuery("#filtered_oldest"),
-	           [ { data: obounced, label: "{$lit['bounced']}" },
-	             { data: oopened, label: "{$lit['opened']}" },
-	             { data: ounopened, label: "{$lit['unopened']}" }],
+	           [ { data: obounced, label: "<?php echo $lit['bounced']; ?>" },
+	             { data: oopened, label: "<?php echo $lit['opened']; ?>" },
+	             { data: ounopened, label: "<?php echo $lit['unopened']; ?>" }],
 	           {
 	        	   series: {
 	        	   	   stack: false,
@@ -1611,12 +1612,13 @@ jQuery(function () {
 	 	        		    right: 10
 	 	        		}
 	 	           },
-	               xaxes: [ { ticks: [[0,"{$lit['last30days']}"],[1,"{$lit['last60days']}"],[2,"{$lit['last90days']}"]] } ],
-	               yaxes: [ { min: 0, tickFormatter: {$tickFormatter} }],
+	               xaxes: [ { ticks: [[0,"<?php echo $lit['last30days']; ?>"],[1,"<?php echo $lit['last60days']; ?>"],[2,"<?php echo $lit['last90days']; ?>"]] } ],
+	               yaxes: [ { min: 0, tickFormatter: <?php echo $tickFormatter; ?>}],
 	               legend: { position: 'ne', margin: [20, 10]}
 	});
 });
-JS;
+        <?php
+        $js = ob_get_clean();
         echo wp_kses_post($js);
 
         exit();

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: MillerMediaNow, mikemm01, MC_Will, MC_Amanda, cornelraiu-1, crstau
 Tags: mandrill, mailchimp, email, smtp, wp_mail
 Requires PHP: 8.1
 Requires at least: 3.0
-Tested up to: 6.9.1
-Stable tag: 1.6.1
+Tested up to: 6.9
+Stable tag: 1.6.2
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -178,6 +178,13 @@ If your account has more than 20 senders registered or more than 40 tags used, t
 4. Dashboard widget Settings
 
 == Changelog ==
+
+= 1.6.2 =
+* Added ABSPATH checks to how-tos.php, lib/reviewNotice.class.php, lib/pluginActivation.class.php, stats.php
+* Fixed missing text domain in bare __(), esc_html__(), esc_attr_e() calls in wpMandrill.class.php
+* Fixed text domain mismatch in how-tos.php (wpmandrill-how-tos -> send-emails-with-mandrill)
+* Replaced heredoc syntax with standard string/ob_start() in wpMandrill.class.php and how-tos.php
+* Updated "Tested up to" to 6.9
 
 = 1.6.1 =
 * Added GPL license declaration to plugin header

--- a/stats.php
+++ b/stats.php
@@ -1,5 +1,10 @@
 <?php
-    if (!current_user_can('manage_options')) wp_die( esc_html__('You do not have sufficient permissions to access this page.', 'send-emails-with-mandrill') );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if (!current_user_can('manage_options')) wp_die( esc_html__('You do not have sufficient permissions to access this page.', 'send-emails-with-mandrill') );
 
     wpMandrill::getConnected();
 ?>

--- a/wpmandrill.php
+++ b/wpmandrill.php
@@ -4,9 +4,9 @@ Plugin Name: Send E-mails with Mandrill
 Description: Send e-mails using Mandrill. This is a forked version of the now unsupported plugin <a href="https://wordpress.org/plugins/wpmandrill/">wpMandrill</a>.
 Author: Miller Media ( Matt Miller )
 Author URI: https://mattmiller.ai
-Version:           1.6.1
+Version:           1.6.2
 Requires PHP: 8.1
-Tested up to: 6.9.1
+Tested up to: 6.9
 Text Domain: send-emails-with-mandrill
 Domain Path: /languages
 License: GPL-2.0-or-later
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 // Define plugin constants
 if ( !defined('SEWM_VERSION'))
-	define( 'SEWM_VERSION', '1.6.1' );
+	define( 'SEWM_VERSION', '1.6.2' );
 
 if ( !defined( 'SEWM_BASE' ) )
 	define( 'SEWM_BASE', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Changes in v1.6.2

### Security & Standards
- **ABSPATH checks** added to `how-tos.php`, `lib/reviewNotice.class.php`, `lib/pluginActivation.class.php`, `stats.php`
- **Missing text domains** fixed in `lib/wpMandrill.class.php`:
  - `__('Setup')` → `__('Setup', 'send-emails-with-mandrill')`
  - `esc_html__('You do not have sufficient permissions...')` → added domain
  - `esc_attr_e('Save Changes')` → added domain

### Text Domain
- Fixed mismatch in `how-tos.php`: `'wpmandrill-how-tos'` → `'send-emails-with-mandrill'`

### Heredoc Removal
- `how-tos.php`: Replaced `<<<HTML` heredoc with string concatenation
- `lib/wpMandrill.class.php`: Replaced `<<<JS` heredoc with `ob_start()`/`ob_get_clean()` pattern

### Version
- Bumped to **1.6.2**
- Updated "Tested up to" to **6.9**